### PR TITLE
Use correct icons for day and night

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,9 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
+        debug {
+            applicationIdSuffix ".debug"
+        }
     }
     
     buildFeatures {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,7 +52,7 @@
 		
 		</activity>
         
-        <provider android:name="net.gitsaibot.af.AfProvider" android:authorities="net.gitsaibot.af" android:exported="true" />
+        <provider android:name="net.gitsaibot.af.AfProvider" android:authorities="${applicationId}" android:exported="true" />
         
         <service android:name="net.gitsaibot.af.AfService" android:permission="android.permission.BIND_JOB_SERVICE" />
     	

--- a/app/src/main/java/net/gitsaibot/af/AfProvider.java
+++ b/app/src/main/java/net/gitsaibot/af/AfProvider.java
@@ -1423,7 +1423,7 @@ public class AfProvider extends ContentProvider {
 				
 				Long weatherIcon = value.getAsLong(AfIntervalDataForecasts.WEATHER_ICON);
 				if (weatherIcon != null) {
-					insert.bindDouble(8, weatherIcon);
+					insert.bindLong(8, weatherIcon);
 				} else {
 					insert.bindNull(8);
 				}

--- a/app/src/main/java/net/gitsaibot/af/AfProvider.java
+++ b/app/src/main/java/net/gitsaibot/af/AfProvider.java
@@ -6,6 +6,8 @@ import java.io.FileNotFoundException;
 import java.util.List;
 import java.util.Map.Entry;
 
+import net.gitsaibot.af.BuildConfig;
+
 import android.content.ContentProvider;
 import android.content.ContentUris;
 import android.content.ContentValues;
@@ -28,7 +30,7 @@ public class AfProvider extends ContentProvider {
 	private static final String TAG = "AfProvider";
 	private static final boolean LOGD = false;
 	
-	public static final String AUTHORITY = "net.gitsaibot.af";
+	public static final String AUTHORITY = BuildConfig.APPLICATION_ID;
 	
 	public interface AfWidgetsColumns {
 		String APPWIDGET_ID = BaseColumns._ID;
@@ -337,7 +339,7 @@ public class AfProvider extends ContentProvider {
 	private static final String TABLE_AIXINTERVALDATAFORECASTS = "aixintervaldataforecasts";
 	private static final String TABLE_AIXSUNMOONDATA = "aixsunmoondata";
 	
-	public static final String AIX_RENDER_FORMATTER = "content://net.gitsaibot.af/aixrender/%d/%d/%s";
+	public static final String AIX_RENDER_FORMATTER = "content://" + AUTHORITY + "/aixrender/%d/%d/%s";
 	
 	private DatabaseHelper mOpenHelper;
 	

--- a/app/src/main/java/net/gitsaibot/af/AfUtils.java
+++ b/app/src/main/java/net/gitsaibot/af/AfUtils.java
@@ -25,6 +25,7 @@ import net.gitsaibot.af.AfProvider.AfSunMoonData;
 import net.gitsaibot.af.AfProvider.AfViews;
 import net.gitsaibot.af.AfProvider.AfWidgets;
 import net.gitsaibot.af.AfProvider.AfWidgetsColumns;
+import net.gitsaibot.af.BuildConfig;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
@@ -595,7 +596,7 @@ public class AfUtils {
 		}
 		
 		return Uri.parse(String.format(US,
-				"content://net.gitsaibot.af/aixrender/%d/%d/%s",
+				"content://" + BuildConfig.APPLICATION_ID + "/aixrender/%d/%d/%s",
 				appWidgetId, time, orientation));
 	}
 	

--- a/app/src/main/java/net/gitsaibot/af/data/AfMetSunTimeData.java
+++ b/app/src/main/java/net/gitsaibot/af/data/AfMetSunTimeData.java
@@ -75,8 +75,7 @@ public class AfMetSunTimeData implements AfDataSource {
 		mDateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
 		mDateFormat.setTimeZone(mUtcTimeZone);
 		
-		mTimeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US);
-		mTimeFormat.setTimeZone(mUtcTimeZone);
+		mTimeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX", Locale.US);
 	}
 	
 	public static AfMetSunTimeData build(Context context, AfUpdate afUpdate)
@@ -177,7 +176,7 @@ public class AfMetSunTimeData implements AfDataSource {
 
 					if (time != null)
 					{
-						long timeValue = mTimeFormat.parse(time.substring(0, 19)).getTime();
+						long timeValue = mTimeFormat.parse(time).getTime();
 
 						if (parser.getName().equalsIgnoreCase("sunrise"))
 						{
@@ -280,6 +279,7 @@ public class AfMetSunTimeData implements AfDataSource {
 			
 			Double latitude = afLocationInfo.getLatitude();
 			Double longitude = afLocationInfo.getLongitude();
+			String offset = afLocationInfo.getOffset();
 			
 			if (latitude == null || longitude == null)
 			{
@@ -297,10 +297,10 @@ public class AfMetSunTimeData implements AfDataSource {
 			{
 				String url = String.format(
 						Locale.US,
-						"https://" + BuildConfig.API_KEY + "/weatherapi/sunrise/2.0/?lat=%.1f&lon=%.1f&date=%s&offset=+00:00&days=%d",
+						"https://" + BuildConfig.API_KEY + "/weatherapi/sunrise/2.0/?lat=%.1f&lon=%.1f&date=%s&offset=%s&days=%d",
 						latitude, longitude,
 						mDateFormat.format(mStartDate),
-						NUM_DAYS_REQUEST);
+						offset, NUM_DAYS_REQUEST);
 
 				HttpClient httpClient = AfUtils.setupHttpClient(mContext);
 				HttpGet httpGet = AfUtils.buildGzipHttpGet(url);

--- a/app/src/main/java/net/gitsaibot/af/util/AfLocationInfo.java
+++ b/app/src/main/java/net/gitsaibot/af/util/AfLocationInfo.java
@@ -1,6 +1,8 @@
 package net.gitsaibot.af.util;
 
 import java.util.TimeZone;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 
 import net.gitsaibot.af.AfProvider.AfLocations;
 import net.gitsaibot.af.AfProvider.AfLocationsColumns;
@@ -264,6 +266,11 @@ public class AfLocationInfo {
 		return mTimeZone;
 	}
 	
+	public String getOffset() {
+		ZoneId zone = ZoneId.of(mTimeZone);
+		return OffsetDateTime.now(zone).getOffset().toString();
+	}
+
 	public String getTitle() {
 		return mTitle;
 	}


### PR DESCRIPTION
SunMoonData: use correct offset.

Call the met.no api with the location offset and convert it to UTC when parsing it

This ensures that the date-time returned from met.no is correct, as if we use a 0 offset the date will be the local today however the time will be UTC leading to sunset happening before sunrise :)

This happens for example in EST when sunset is after 8 PM causing the UTC sunset to be after midnight. (the further one is from UTC the more often this happens)

Please rebase.
And please make a new release as this bug is quite annoying.

Thanks